### PR TITLE
大丰食祭剧本主线剧情（部分）

### DIFF
--- a/localized_data/stories/story/data/08/0000/storytimeline_080000007.json
+++ b/localized_data/stories/story/data/08/0000/storytimeline_080000007.json
@@ -57,7 +57,7 @@
     },
     {
       "Name": "索侬艾尔菲",
-      "Text": "大家好！终于要开始了哦！！\n决出No.1马娘运动员的祭典――",
+      "Text": "大家好！终于要开始了哦！！\n决出No.1马娘运动员的盛会――",
       "ChoiceDataList": [],
       "ColorTextInfoList": []
     },
@@ -69,7 +69,7 @@
     },
     {
       "Name": "索侬艾尔菲",
-      "Text": "Umamusume Athletic Festival！！",
+      "Text": "Umamusume Athletic\nFestival！！",
       "ChoiceDataList": [],
       "ColorTextInfoList": []
     },
@@ -141,7 +141,7 @@
     },
     {
       "Name": "合成音",
-      "Text": "U.A.F.Ready GO!\n~运动员们的闪耀时刻~",
+      "Text": "U.A.F.Ready GO!\n～运动员们的闪耀时刻～",
       "ChoiceDataList": [],
       "ColorTextInfoList": []
     }

--- a/localized_data/stories/story/data/08/0000/storytimeline_080000008.json
+++ b/localized_data/stories/story/data/08/0000/storytimeline_080000008.json
@@ -1,0 +1,95 @@
+{
+  "Title": "序章",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "食物——是赛马娘力量的源泉！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "刻苦锻炼，勤奋学习，努力跑步——\n还有好好吃饭！这才是健康的学园生活！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "——为了这个目标！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "哦！早上好，训练员！\n今天也一起流汗吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "堆肥是土壤的食物，肥料是蔬菜的食物！\n大家一起好好搅拌吧～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "嗯！美味地成长，美味地成长♪\n蔬菜先生～♪",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "哇，闪闪发光，光洁亮丽……！\n最棒的蔬菜们长成了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "好嘞！\n大家，把它们变成美味的料理吧～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "大家",
+      "Text": "哦哦～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "大家",
+      "Text": "我开动了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "种植、收获、料理……\n与大家一起度过的日子，一定是无可替代的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "然后，最终的目标是——\n我们最初的心愿！赛马娘们的幸福！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "那么——今天也一起努力吧！训练员！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "合成音",
+      "Text": "收获！饱腹！大丰食祭！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008000.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008000.json
@@ -1,0 +1,395 @@
+{
+  "Title": "开幕！大农耕时代！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（“食”——这是奔跑者力量的根源）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（当然！在特雷森学园，\n学生们所吃的食物也得到了\n最大限度的关注与关心——）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "特雷森学园"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "理事长，在线会议辛苦了。\n……咦？您要去哪里？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯！离下一项安排还有一个小时！\n我去看看田地的情况！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "……是关于品种改良的事吗？\n请不要太勉强自己哦？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯～嗯。糖度9.5。\n相当不错——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "维生素含量有比上次增加吗？\n带回去研究一下吧……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（这是给学生们的理想食物。\n我一直在工作之余为此努力着）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（日常的照顾，土壤的培育，虫害和动物的防范。\n为了品种改良，需要采取无数的措施！）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（虽然已经持续了很长时间——\n但还没有达到理想状态——）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……唔嗯。β胡萝卜素，维生素C，铁，钙。\n品种改良的成果在数据上有所体现……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "现在还需要的是糖度！学生们喜欢甜味！\n所谓食物不仅要满足身体，也要满足心灵！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……仍有改进的余地！\n要重新考虑土壤的培育。嗯～……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "…但是，今天真是个晴天！\n温暖！舒适的春日！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "…………。\n……呼啊～。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……不行不行！不能被困意打败！\n确实最近很忙……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "…………。……呼……呼。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯嗯……？\n这、这是什么景象……？这里到底是……？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "什么……！？三、三女神……！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "达利阿拉伯",
+      "Text": "——想要照顾学园所有学生的你。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "拜耶尔土耳其",
+      "Text": "希望所有学生追逐梦想，奔跑不止的你。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "高多芬阿拉伯",
+      "Text": "祈愿所有学生健康成长的你。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "达利阿拉伯",
+      "Text": "请收下我们的，微小祝福——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "三女神",
+      "Text": "至于如何利用——取决于你和学园的大家。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "——啊！？是、是梦吗！？\n……就算是梦也……！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……什么！？\n田地在一瞬间闪了一下……！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……怎么回事。\n蔬菜和土壤，看起来比之前更耀眼了……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "我这是……还在做梦吗……？\n…………。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "——哎呀，不管是不是梦！\n吃了就知道了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……？！这、这味道……！？啊——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "好甜啊～～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "这……糖度超过12！\n这甜味和美味……！\n还有，体内涌出的活力……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "…………。\n终于……终于，完成了吗……？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "我所追求的蔬菜！给学生们的理想食物！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……不能耽搁！\n作为理事长，现在有我必须要做的事情！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "各位学生和训练员们！很抱歉临时召集你们！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "那么！在开始之前！首先是……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "——请享用！！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "这，这是什么胡萝卜！？\n好好吃～～～～！！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "土豆和草莓也是……！\n这是米浴第一次吃到这么美味的蔬菜……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "米浴"
+      ]
+    },
+    {
+      "Name": "西野花",
+      "Text": "不仅是好吃……！\n每吃一口，感觉都有力量涌上来……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "浑身充满美食力量～！好厉害！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "呵呵呵……其实这些全都是，\n这个学园的田地里种出来的蔬菜！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "真的吗！？\n之前就很好吃了，现在突然提升了这么多！？\n到底是怎么做到的……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "好了！那么，现在进入正题！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "各位！\n对你们这些运动员来说，食物是什么！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "食物，是构成身体的源泉！\n是奔跑的活力！是每天的喜悦！\n是你们的生命！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "因此，作为学园理事长，\n为了制作优质蔬菜——理想的营养食物，\n我不断地尝试和改进。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "结果就是——刚才大家品尝的蔬菜！\n作为孕育这些蔬菜的土壤！\n学园的田地现在正处于绝佳状态！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "——学生和训练员们！\n为了利用这次机会，请助我一臂之力！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "进一步开发和发展田地！\n种植和收获新蔬菜！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "还有，开发新食谱！\n适合奔跑者的，最好的营养食物！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "为了让这个学园成为美食的理想乡！\n请大家助我一臂之力！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "今天——此时此刻！\n所有田地都将为诸位开放！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "这就是说……\n可以尽情种植那些美味的蔬菜吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘B",
+      "Text": "……我、我想试试……",
+      "ChoiceDataList": [
+        "（理想的营养食品吗……）"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "美味满满的蔬菜……！\n那一定很buono（好吃）吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "如果努力的话，\n一定会种出美味的蔬菜吧……嗯嗯。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……请允许和诸位分享我的梦想。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "我想看到的。是充满学园的理想食物——\n以及你们充满喜悦和活力的身影。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "健康成长，没有伤病——\n就这样尽情奔跑下去。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "为了抓住自己的梦想——\n无论何处……无论何处！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "各位！那样的未来……\n让我们一起抓住吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008001.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008001.json
@@ -1,0 +1,289 @@
+{
+  "Title": "集结！田地里的伙伴们！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "——自从秋川理事长发布公告以来，\n田地周围总是有学生和训练员的身影。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "秋川"
+      ]
+    },
+    {
+      "Name": "青云天空",
+      "Text": "哈～，这土壤真是了不起啊～。\n爷爷要是看到一定会很感慨的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "圣王光环",
+      "Text": "真、真的有那么厉害吗？这土？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "青云天空",
+      "Text": "嗯，只有继承了“农”之血的人才懂。\n不太重也不太轻，富含有机物。\n青云天空我啊，只要一眼就能分辨出土的好坏。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "青云天空"
+      ]
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "啊。\n要制造出这样的土，一定花费了不少工夫吧。\n而且还是无农药的？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "这么大的田地，\n都是理事长一个人照顾到现在的吧……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（……那真的是梦吗）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（为了学生的饮食，付出的努力……\n难道是三女神为了回报而创造了奇迹……？）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（……想了也不会有答案。不管怎样——）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（学园饮食的未来！希望三女神也能守护！）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……那么，各位！尽情地参观吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "现在把上次收获的部分送给大家！\n不管是开始种菜的学生还是不种菜的学生，\n都可以随便拿！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "…………。嗯……。",
+      "ChoiceDataList": [
+        "怎么了？",
+        "怎么了？"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "那个……\n米浴也对种菜感兴趣，但是……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "像我这样的人，\n真的能好好照顾这些蔬菜们吗……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "这什么话嘛～！试试看总会有办法的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "农活只要合作起来就能事半功倍。\n不一定要一个人做哦？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "我们有在帮忙家里的农活！\n有什么不懂的可以教你！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "诶？但是……米浴可以吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "当然可以！\n而且我从米浴同学身上嗅到了同伴的味道！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "同、同伴？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "米浴同学当时的表情……\n吃完蔬菜后的那种眼神――\n我感觉到了。你在想和我一样的事！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "这么美味的蔬菜，怎么样都吃不够……\n你当时就是那种眼神！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "唔，确、确实是这样……\n但、不要说出来啊～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "哈哈哈，这不是挺好的吗！\n要是种田的话，爱吃蔬菜可是最大的才能。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "在这里相遇也是缘分。\n不如我们一起种田吧？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "现在大家都在关注田地。\n这样的话，让我们种出最强的蔬菜吧！",
+      "ChoiceDataList": [
+        "是啊！",
+        "是呢！"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "嗯，嗯……！请多关照……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "太好了！饱腹同盟成立！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "？？？",
+      "Text": "那个！我们也想加入这个同盟！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "我、我当时也被感动了……\n原来有这么美味的蔬菜。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "所以，我想，既然有这么棒的蔬菜，\n如果能做出最美味的料理就好了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嗯嗯！多做些料理，大家就能更开心了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "呃……比如，能做什么样的料理呢？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嗯～☆咖喱啊，三明治啊。\n还有炖菜和加了大蒜的拉面。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "蔬菜披萨、麻婆豆腐……\n总之可能性是无穷的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "哦哦……！好想吃……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "好棒……！\n米浴的梦想越来越大了……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "等蔬菜成熟后，大家一起做各种料理也不错。\n就像试吃会一样。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "试吃会"
+      ]
+    },
+    {
+      "Name": "米浴",
+      "Text": "试吃会……！\n想、想做！米浴想做！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "好，燃起来了！\n接下来就拼命种菜吧！然后做各种美味的料理！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "四人",
+      "Text": "哦～！",
+      "ChoiceDataList": [
+        "哦～！"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……嗯嗯。\n努力耕作，辛勤培养，健康饮食――\n像茂盛的蔬菜一样健康成长吧。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……那么！我也来流点汗吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008002.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008002.json
@@ -1,0 +1,354 @@
+{
+  "Title": "教程",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "辛苦了。\n现在正在为有需要的人进行『大丰食祭』\n的详细说明——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "<username>先生，需要说明吗？",
+      "ChoiceDataList": [
+        "听说明",
+        "不听说明"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "那么，请问要说明什么呢？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "独白",
+      "Text": "关于『大丰食祭』的育成，我想请问——",
+      "ChoiceDataList": [
+        "关于料理挑战",
+        "关于蔬菜的收获",
+        "关于料理",
+        "关于田地",
+        "已经没问题了"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "是关于『料理挑战』吧。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "『料理挑战』是一项为了加深对食物理解\n的活动，大家会挑战各种料理。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "用培育的蔬菜来制作料理，并且会举行四次\n『试吃会』，让大家品尝。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "根据试吃会前获得的『料理Pt』，在『试吃会』\n上马娘们的满意度会有所不同。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "试吃会前获得的",
+        "『料理Pt』"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "如果让大家大满足的话，大家对料理的\n热情也会提高，制作的料理效果也会改变！\n马娘们也能得到巨大的成长！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "加深对食材和料理的理解——让我们一起用\n更好的料理让马娘们变得更强更健康吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "然后……在古马级12月后半，\n将会举办最后的料理挑战『大丰食祭』！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "古马级"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "这是一个充分利用之前积累的食物知识的\n大型活动……请大家一定要向参加者们展示\n自己引以为傲的料理！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "另外，\n这次大家将会一边参加闪耀系列赛，\n一边参加料理挑战。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "一边参加闪耀系列赛"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "根据育成的情况，\n在料理挑战期间也可能终止育成，\n请务必注意哦！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "根据育成的情况",
+        "料理挑战期间",
+        "终止育成"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "关于『料理挑战』的说明就到这里。\n还有其他想要了解的吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "是关于『蔬菜的收获』吧。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "这次，你将收获五种蔬菜，\n一边制作有助于训练的料理，\n一边以达成培养目标为目标。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "收获五种蔬菜",
+        "有助于训练的料理"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "所有种类的蔬菜每4回合收获一次，\n但收获数量会根据各蔬菜的Lv变化。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "每4回合",
+        "收获数量",
+        "各蔬菜的Lv"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "为了提升蔬菜Lv所需的『农田Pt』，\n可以在收获的同时获得。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "在收获的同时获得"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "而且——进行各项训练时，\n可以获得各种蔬菜的『照料印章』！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "各种蔬菜的『照料印章』"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "获得照料印章的蔬菜可以比平时收获更多。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "比平时收获更多"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "另外，即使进行『休息』『外出』『保健室』\n『比赛』也能获得照料印章。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "不过……在训练以外获得的照料印章种类\n每次都不同，请仔细确认哦。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "此外，满足友情训练等条件时——\n照料印章会变成『悉心照料印章』！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "变成『悉心照料印章』"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "悉心照料印章越多，收获数量也会增加！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "收获数量也会增加"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "有效率地收获蔬菜，制作更多料理，\n训练效果也会提升！加油哦！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "关于『蔬菜的收获』的说明就到这里。\n还有其他想要了解的吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "是关于『料理』吧。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "通过消费食谱所需的蔬菜，可以制作『料理』。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "每次制作料理，都可以获得影响『试吃会』\n满意度的『料理Pt』哦！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "不仅如此，吃料理还可以获得各种效果！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "比如，提升训练和比赛中获得的基础能力\n和技能Pt、恢复体力等等♪",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "另外……料理有时会『大成功』。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "从『大成功』的料理中，\n除了普通的料理能得到的效果之外，\n还能获得各种追加效果！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "获得各种追加效果"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "此外，每次试吃会后，\n料理获得的效果也会增加，\n还可以制作新的料理。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "效果也会增大",
+        "新的料理"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "不断积累料理经验，并在训练中加以利用吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "关于『料理』的说明就到这里。\n还有其他想要了解的吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "是关于『农田』的吧。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "在农田里，通过提升蔬菜Lv，可以增加\n各蔬菜的收获量，提高料理的效果。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "增加收获量",
+        "提高料理的效果"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "提升蔬菜Lv需要在收获时获得的『农田Pt』。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "蔬菜Lv越高，\n需要的『农田Pt』也越多，请务必注意。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "需要的『农田Pt』也越多"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "另外，蔬菜Lv是有上限的……\n但通过让大家在『试吃会』上满足，\n可以追求更高的等级！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "在『试吃会』上满足",
+        "可以追求更高的等级"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "关于『农田』的说明就到这里。\n还有其他想要了解的吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "真的没问题了吗？",
+      "ChoiceDataList": [
+        "是的",
+        "不"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "明白了♪\n为了以防万一，这里有简单总结的内容。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "刚才的说明可以随时通过点击左上角的\n『i按钮』查看。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "i按钮"
+      ]
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "那么，请加油哦。\n我会在背后默默支持你的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "明白了。那么，请加油哦！\n我会在背后默默支持你的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008003.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008003.json
@@ -1,0 +1,713 @@
+{
+  "Title": "合宿！农家体验！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "开始农业生活有一段时间了。\n大家似乎渐渐适应了作业——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "请大家稍等。米浴现在去浇水——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "啊，今天没关系的，米浴同学！\n浇太多水反而会让根不容易生长的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "诶！？对，对不起……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "……呼啊……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "哎呀，你还好吗？\n小花，你是不是没怎么睡觉？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "小花"
+      ]
+    },
+    {
+      "Name": "西野花",
+      "Text": "啊！？对、对不起！我没事的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "……今天的米浴，差点对蔬菜们做了坏事……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "我也有点困……\n明明菱曙同学一直都在精神地工作着……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "菱曙"
+      ]
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "什么啊，别在意！才刚开始嘛？\n我们很愿意帮忙的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "但、但是……米浴可能又会做错什么……\n我得再多学习才行！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "我也……要更努力，习惯早起……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "嗯……有点担心呢。那两个人，太紧张了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "其实不用当作做题一样。\n只要轻松地去做就好了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "不过，她们的热情很强烈！这一点值得肯定。",
+      "ChoiceDataList": [
+        "要考虑让她们快乐地学习的方法呢"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "…………对了！我有个好主意！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "原来如此……浇太多水会让蔬菜误以为\n不用长太多根啊……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "嗯，早起的秘诀是……\n把窗帘稍微拉开一点——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "嗯嗯，看起来你们两个都在努力呢！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "我想了个办法。\n我们不如来搞个『睡衣派对』怎么样？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "睡、睡衣派对？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "嘛，其实不是去玩，而是『合宿』啦。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "周末大家一起聚在一起。\n体验一天真正的农家生活！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "然后晚上在田边搭帐篷。\n住在田边，熟悉农业生活。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "我有个大帐篷，可以让大家都住进去哦！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "我觉得到时候自然就习惯农业了。\n怎么样，试试吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "……米浴会加油的！为了蔬菜们！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "我、我也会努力的！请多关照！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "就这样，\n本周末将举行“农家一日体验住宿会”。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "好的！\n那么，我和米浴同学还有训练员一组，\n菱曙和西野花同学一组，分工进行！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "菱曙"
+      ]
+    },
+    {
+      "Name": "大家",
+      "Text": "好——！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "你们两位听好了。\n要把土和肥料混合在一起，\n就像在给蔬菜们做床铺一样。",
+      "ChoiceDataList": [
+        "床铺？"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "是啊，土会变得松软。\n这对蔬菜来说是理想的状态。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "那、那就是说……我们努力的话，\n蔬菜们就能在暖和的床铺上睡觉？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "没错。怎么样，\n贴心的人做这种事也会更细心吧？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "嗯……！\n米浴会努力把床铺做得蓬松的……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "加油，加油……！\n杂草们，对不起……\n但必须要拔掉你们……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "哦～，干得真漂亮，花同学！\n我教你更高级的技巧吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "有些杂草只留根部就好！\n这样杂草的根还能帮助松土呢！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "哇～杂草们也在帮忙种蔬菜呢～！\n真了不起！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "原来如此……这个技巧也能在花坛里用呢。\n那个，割断的位置有讲究吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "是的！\n瞄准靠近根部『生长点』的稍微下面——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "啊～……好累啊～……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "辛苦了！出了好多汗啊！\n那么，接下来开始一天中最重要的工作吧。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "重、重要的工作……！\n无论什么工作，米浴都会全力以赴的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "我也是！是什么工作呢！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "嘿嘿，那就是……午睡啦！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "啊！？午、午睡……？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "是啊。全力工作后，在草地上好好休息。\n然后充满能量，再继续努力。\n这种感觉很棒哦。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "但、但是……这样真的好吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "嘿，农活可不只是工作哦。\n而且，特别是米浴和花！",
+      "ChoiceDataList": [
+        "今天你们两个比谁都努力啊！",
+        "今天你们两个比谁都努力呢！"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "…………！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "没错没错！太阳也在说要休息啦～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "树荫下的好位置先到先得哦～！\n那么开始吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "啊……真的……好舒服啊……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "…………。呼……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "哇……！田地变得好干净！\n花同学，你好厉害……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "米浴同学也一样！\n那边都是你一个人耕的吧？",
+      "ChoiceDataList": [
+        "两个人的表情都很明朗啊",
+        "两个人的表情都很明朗呢"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "嗯……！\n今天虽然很累……但感觉很开心……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "好嘞！大帐篷完成了～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "真、真的要在这里过夜啊……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "嘿嘿，果然会兴奋吧。\n我带了扑克牌哦。会玩大富翁吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "我还带了很多肉哦～！还有咖喱呢！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "我带了果汁和点心！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "哇～！葛城同学带了扑克牌，菱曙同学\n带了肉和咖喱，那理事长带了——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "葛城"
+      ]
+    },
+    {
+      "Name": "西野花",
+      "Text": "……理事长！？您怎么在这里！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嘿嘿，看到你们这么努力！我来送些东西！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "不过，我的目的仅此而已！\n剩下的时间你们好好享受吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "啊？这么快就要走了吗……？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯……如果回去太晚的话，手纲就会……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "手纲"
+      ]
+    },
+    {
+      "Name": "米浴",
+      "Text": "啊，难得来一次住宿会，一起吃个饭吧……\n怎么样？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "确实，至少吃个饭吧？大家说呢？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "没问题！\n这是和理事长一起策划的合宿嘛！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯……但是……",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "很多人一起的话，肯定会很好吃的！\n理事长！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……那么……我就稍微打扰一下！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "——啊～～～～！失败了！\n又是大贫民！不甘心～～～～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "嘿嘿，那就再来一局……\n诶，已经这么晚了？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "那么～，大家赶紧铺好睡袋吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "我、我……能好好起床吗……？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "嗯嗯。不如来玩我家的早起游戏吧？",
+      "ChoiceDataList": [
+        "早起游戏？"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "在我家，每天早上固定时间，\n公鸡一叫，我们就会醒来。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "然后看谁能最快准备好，先到田地……\n我和妈妈经常这样比赛！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "现在稍微改变一下，谁先早起，\n模仿公鸡叫声叫醒大家，谁就赢！\n怎么样？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "嘿嘿，听起来很有趣！\n谁能第一个成为公鸡呢～？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "米浴……会加油的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "我、我也会……绝对要叫醒大家！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "夜晚就这样渐渐过去——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "？？？",
+      "Text": "——喔喔喔～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "！？谁……谁在叫啊……！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "哈哈……是我！",
+      "ChoiceDataList": [
+        "理事长！？"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "哈哈，\n别看我这样，平时也在照顾田地！\n早起已经习惯了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "不、不愧是理事长……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "哼哼！让我们开始新的一天吧！各位！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "大家",
+      "Text": "好—！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "——呼～，大家辛苦了！\n那么终于，合宿要结束了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "这可是劳动者的特权……\n看看，有几颗已经熟了吧？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴等人",
+      "Text": "！美味……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "嗯，真是得意之作！\n这是我们亲手种的蔬菜哦！大家！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "我们……亲手种的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "……平时投入多少精力，蔬菜就会有多少回应。\n当然，这不只是一天的成果。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "米浴……小花……\n我们的心意，都传达给了蔬菜们。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "……嗯！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "——太、太好了！\n今天我第一个起床了……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "米浴迟了一些……！可惜……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "嘿嘿，怎么了？\n最近你们俩，精神特别好啊。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "嗯，因为……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "自从上次合宿后……\n总觉得来田里很开心……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "……嘿嘿，是吗。那就好。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "（……谢谢理事长，\n两个人都变得更开朗了！）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……那个，手纲～。\n能不能稍微去田里一下……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "不行！理事长突然消失不见……！\n工作都堆积如山了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "唔唔唔……这就是代价啊！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008004.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008004.json
@@ -1,0 +1,95 @@
+{
+  "Title": "试吃！收获的成果！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "独白",
+      "Text": "一年即将结束，\n大家也逐渐习惯了种植蔬菜——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "大家！是时候休息一下啦～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "哈哈。蔬菜长得越来越好了呢～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "说得是！今天作业的时候，\n好几次都差点忍不住咬一口……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "那、那个……我理解你的感受。嘿嘿。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "不过，好不容易种出来的蔬菜，\n一定要好好料理才行哦。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "哈哈哈。\n那么趁着我们还能忍住，我有个提议。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "我们之前说的试吃会，差不多可以开始了吧？\n从这些长得好的蔬菜里挑选一些，\n大家一起做菜吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "每个人做自己想吃的料理。怎么样？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "哇哦，很不错！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "尝试各种料理，说不定还能想到新的食谱呢！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "好～，想到什么就做什么！\n美味的料理永远不会嫌多嘛！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "嗯嗯……我的肚子已经开始咕咕叫了！\n什么料理都欢迎哦～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "好！那我们就赶紧开始吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008005.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008005.json
@@ -1,0 +1,41 @@
+{
+  "Title": "大满足！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "两人",
+      "Text": "嗯～！每道菜都很好吃～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "真的呢！\n嘿嘿，我们真是种了不起的蔬菜啊！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "平时努力做料理真是太好了……\n哈哈……♪",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嗯嗯，这次的试吃会真是太棒了♪",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "累积的美味，乘以十倍！\n今后也要多做料理，\n把美味的蔬菜变得更加美味！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008006.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008006.json
@@ -1,5 +1,5 @@
 {
-  "Title": "满意！",
+  "Title": "满足！",
   "TextBlockList": [
     {
       "Name": "",

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008006.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008006.json
@@ -1,0 +1,41 @@
+{
+  "Title": "满意！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "大家",
+      "Text": "谢谢款待～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "嗯！味道还行，对吧？\n试吃会挺不错的嘛。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "不过，考虑到蔬菜的美味……如果再\n研究一下的话，可能会做得更好……\n是吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "对啊！\n做料理做料理，让它们变得更好吃！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "好！我们一起做更多的菜吧！大家！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008007.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008007.json
@@ -1,0 +1,572 @@
+{
+  "Title": "研究！与“食”同行！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "某天，在学园的跑道上看到了美浦波旁的身影。\n她似乎在进行非常高强度的训练——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "美浦波旁"
+      ]
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "…………。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "怎、怎么了？波旁同学？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "波旁"
+      ]
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "（……嗯～）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "体内能源……枯竭。全部系统确认瘫痪……。\n错误错误错误……。",
+      "ChoiceDataList": [
+        "糟、糟糕！？",
+        "糟、糟糕！？"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "来～吃吧～吃吧～！还有很多呢！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "非常感谢……我开动了……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "哈哈，吃得真香啊。\n做饭的人也很高兴呢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "不过，你真的很努力啊……\n都累得动不了了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "……我的适应性本来是短距离。\n为了挑战长距离，必须要进行高强度的训练。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "但是——最近训练时经常能量耗尽——\n虽然我已经很注意了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "……总之，非常感谢。\n我该回去继续训练了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "但、但是，真的没问题吗？\n再倒下的话……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "……为了我的梦想，\n我知道半吊子的训练计划是不够的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "那、那个……米浴也明白……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "…………。\n那、那个，用料理来支持你怎么样？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "有助于疲劳恢复、易于消化、\n能够迅速转化为能量的料理……\n如果能帮上一点忙就好了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "我本来就对料理很感兴趣。\n如果可以的话，我想做很多料理……\n怎、怎么样？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "但是……我不能这样麻烦花同学……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "让、让米浴也帮忙……！\n因为，我一直看着波旁同学这么努力……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "如果我们的蔬菜能帮上一点忙的话……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "……我们的人都这么说了。\n怎么样？对我们来说也是一种学习！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "……非常感谢。那么……拜托了，各位。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "于是，大家决定用“食物”来支持美浦波旁。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "呼！呼！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "重量训练、高负荷的循环训练……都完成了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "波旁同学，辛苦了！\n这是我和花同学一起做的料理……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "因为是重量训练后……！\n所以做了植物蛋白满满，\n豆类丰富的炖菜！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "状态……『饥饿』。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "真是辛苦了……！\n用于疲劳恢复的蒜香蔬菜汤面，请用！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "呼……呼……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "波旁同学，最近状态不错呢！\n料理的效果表现出来了吗？\n希望是这样……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "……咦？波旁同学……动不了了？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "……能量……耗尽……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "糟、糟糕！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "唔……长时间运动，能量还是不够……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "长距离的壁垒……比想象的还要厚。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "嗯～……\n能制作提升耐力的特别料理就好了吧……？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "（耐力……能量……。\n为了长跑，必须在“食物”上重视的……\n是什么呢？）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "日后——在图书馆，\n看到了正在寻找资料的西野花和米浴。",
+      "ChoiceDataList": [
+        "是为了美浦波旁收集资料吗？",
+        "在为美浦波旁收集资料吗？"
+      ],
+      "ColorTextInfoList": [
+        "西野花",
+        "米浴"
+      ]
+    },
+    {
+      "Name": "西野花",
+      "Text": "是的。有些陷入困境了……\n这种时候，从基础开始重新学习，\n或许会有新的想法。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "不过，这里藏书量真是惊人啊……\n即使同是营养学的书籍，细分领域也很多，\n找到好书真是困难——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "那么！用这些资料看看吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "秋川理事长旁边——\n是堆积如山的书籍和文件！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "荒漠英雄",
+      "Text": "听说你们在努力开发新菜单……！\n就和理事长一起，找来了推荐的书！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "还有在学园收集的数据！以及我的私人笔记！\n一定会有所帮助的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "理事长，荒漠英雄同学……\n非、非常感谢！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "荒漠英雄"
+      ]
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯。虽然有很多学生在努力进行营养管理，\n但能彻底理解理论并付诸实践的人……\n还是少数！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "你能若能取得成果，就能激励学生们，\n对整个学园都有好处！我期待你们的表现！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "……！我、我们会努力的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯！还有一件事！\n开发新菜单当然很好——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "但不仅要关注“什么样的食物”，\n还要思考“怎么吃”，“什么时候吃”——\n答案也许隐藏在其中哦？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "理事长……？那是——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "没什么，你们很快就能找到答案的！\n那么，加油吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "过了一段时间——\n在美浦波旁参加一场模拟比赛时。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "……呼！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "哈啊，哈啊……\n波、波旁同学，什么时候变得这么……！\n在长距离赛中，最后还能保持不减速……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘B",
+      "Text": "是、是啊，我听说了！\n波旁同学，请西野花她们制作了充满营养的\n秘密菜品！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "……确实。\n这次，得到了花同学她们的全力支持。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "真、真的吗？\n是什么秘密菜单！？我也想知道！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "……其实……菜单本身，\n并没有特别的东西。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘B",
+      "Text": "诶……？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "嘿嘿……其实是这样的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "……我们重新学习了理事长给的资料。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "——嗯，每顿饭，主食，主菜，副菜。\n各自应该摄取的营养——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "有助于疲劳恢复的……维生素C，柠檬酸。\n主要在绿黄色蔬菜、柑橘类——输入完毕。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "早上好。晚餐后3小时，按计划入睡。\n8小时睡眠，完成。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "但是，为此……删除了一项计划。\n晚上的跑步无法进行了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "对、对不起。但是……\n从长远来看，这样是最好的……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "我并没有怀疑。\n花同学，米浴同学……我相信你们。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "波旁同学……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "当然，每顿饭都采用了营养丰富的菜单——\n但更重要的是生活习惯和饮食时间。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "不过……为了比赛，我还准备了一个秘密武器！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "——秘密·计划。“糖原装载”。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "啊？真……真的是秘密武器！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "不不！所谓糖原装载——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "荒漠英雄",
+      "Text": "不仅是平时的训练，这是食物在实战时的运用。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "荒漠英雄",
+      "Text": "糖是重要的能量来源……其中重要的是糖原。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "荒漠英雄",
+      "Text": "但，身体能储存的糖原有限……\n不注意的话，很快就会耗尽。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "荒漠英雄",
+      "Text": "——因此，\n为了在比赛当天尽可能储存更多的糖原，\n要制定平时的食谱。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "荒漠英雄",
+      "Text": "这就是，糖原装载！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "嗯嗯……\n说起来，我的训练员也提到过糖的事情……\n在课上也听说过……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘B",
+      "Text": "……果然自己也要好好学习！\n好，我也要加油～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "……这次真的非常感谢。各位。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "不不！我们才是……！\n因为波旁同学，我们学到了很多……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "最开始只想着做出惊人的菜单……\n但现实不是这样的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "就像理事长说的……平时什么时候吃，\n怎么吃，真的会影响跑步的表现。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "……这次，我获得了重要的武器。\n今后，我也会学习关于食物的知识。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美浦波旁",
+      "Text": "如果有机会……我会在赛场上展示成果。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "……嗯！我们也会继续学习的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……嗯嗯。了不起！\n你们果然没有让我失望！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008008.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008008.json
@@ -1,0 +1,453 @@
+{
+  "Title": "节制！还有口福！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "独白",
+      "Text": "因为努力种植蔬菜——\n最近食堂里的学生们脸上笑容更多了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "胜利奖券",
+      "Text": "唔唔唔！！每样东西看起来都好好吃啊！！\n我 要 开 动 啦！！！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "成田大进",
+      "Text": "啊～真是的，安静点儿吧！\n虽然好吃，但吃饭时要安静点！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嘿嘿～。大家都吃得很开心呢！\n真高兴啊♪",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "作为制作者，\n看到这样的场景真是太高兴了……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "是啊……真的……非常高兴……啊……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "你、你没事吧！？\n看起来一点也不开心啊？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "……其实我一点也不好。\n现在的学园是——温柔的地狱！",
+      "ChoiceDataList": [
+        "什……为什么！？"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "因为……因为……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "每样东西都……真的，太好吃了～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "……如果吃胖了就跑不动了。\n最重要的是比赛……我明白的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "但是……！我还是想吃！全部都想吃！\n肚子是不会骗人的～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "啊啊，食堂……\n对我来说既是天堂也是地狱……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "…………。\n你啊……我还以为是个多严重的烦恼呢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "但、但是，我能理解你的感受！\n营养管理和体重控制真的很难啊……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯！确实，这是不可小觑的难题！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "作为运动员，节制是必须的。\n因此，很多学生都在忍受饥饿！\n比如，那边的——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "小栗帽",
+      "Text": "…………。咕噜……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "目白麦昆",
+      "Text": "草莓，草莓……你最想让谁吃呢……。\n……没什么，别在意。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "咳咳！\n虽然有些例子可能太极端了——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "但是，如果过度节制，\n反而会导致身体状况变差，影响表现。\n这确实是一个难题！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "…………。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嗯～……\n不能好好享受美食，真的很痛苦。\n…………。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "嗯，饱腹感强，低卡路里……。\n营养均衡，还得——嗯，真难啊……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "好～！小花辛苦了！让我也加入吧～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "蔬菜军团也到了！可以做很多试作品啦～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "啊，菱曙同学！谢谢……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嘿嘿。虽然忍耐也很重要，\n但我还是想全力以赴地和大家一起享受！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "吃饭的时候，必须从心底感到幸福！\n小花你也是这样想的吧？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "……是的！\n如果能制作出兼顾节制和饱腹感的料理……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯！\n虽然力量微薄，但我也会尽力帮助的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "咦？理事长也来了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "哈哈哈，这也是为了学生们！\n我会帮忙剥皮什么的！而且……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（咕～…）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "我也能做试吃员……！\n为了理解学生们的感受，我努力工作，\n饿着肚子来了……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "理事长……！\n……好。不管怎样，先开始动手吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯！这个硬麻婆豆腐，好吃！\n把低卡路里的豆腐特意煮得很硬，增加咀嚼次数，\n增强饱腹感！完美！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嘿嘿！很厉害吧！\n我把豆腐的水分挤得很干净呢～☆",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "……对了！如果把蔬菜加入拉面的面条里，\n或者把配菜处理得有咬劲的话……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "……好！\n那就开始完善试作品，制作正式的食谱吧——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "食……物。食物……好香啊～……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "…………。刚刚是谁？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "小栗帽",
+      "Text": "食材的～香味～……\n胡萝卜，土豆，大蒜，辣椒，草莓……\n好多好香的味道……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周&小栗帽",
+      "Text": "想吃……想吃……这里……打开……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "哎呀，糟糕了！？\n小特和小栗的肚子饿得失控了～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "小栗"
+      ]
+    },
+    {
+      "Name": "西野花",
+      "Text": "糟糕……！\n食谱快完成了，现在如果食材被吃了……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯嗯……！我来负责引开她们！\n拿着其中一个试作品逃走，在完成之前吸引视线！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "哎？！那样太危险了～！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "为了学生！教育就是不顾一切！嗖！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周&小栗帽",
+      "Text": "给我饭吃～～！给我饭～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "哇～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "理事长……！请保重……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "现在只能相信理事长了～！\n我们必须尽快完成菜单！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "哈，哈……给～我～饭～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "遗憾！到此为止了吗！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "等等～！食谱完成了～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "来吧！\n小特和小栗同学，这道料理请享用！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "小栗帽",
+      "Text": "这，这个……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周&小栗帽",
+      "Text": "……好好吃！！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "真是的，我都以为不行了，\n但能顺利发布真是太好了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "真是谢谢大家了！从头到尾……！\n没有理事长的话，肯定完成不了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "不不！应该谢谢的是我！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "看啊！在吃你们料理的学生的表情！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "目白麦昆",
+      "Text": "——诶！？\n吃这么多，还不到200卡路里！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "米浴，可以再来一碗吗……？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "吃吧吃吧～！\n这是理事长也帮忙完成的料理，为了大家！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "啊～……！谢谢款待……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "小栗帽",
+      "Text": "真想连盘子都吃了……谢谢款待……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "作为运动员，节制是重要的！\n但是……如果心灵得不到满足，\n就无法说有健康的生活。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "你们创造了突破这个矛盾的食物！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "我的心也得到了满足！\n因为看到了学生们的笑脸！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "理事长……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "咳咳！那么，告辞！我要回去工作了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008009.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008009.json
@@ -1,0 +1,107 @@
+{
+  "Title": "启动！超级蔬菜机械！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "快要到合宿了啊……暂时得和田地告别了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "离开的时候，总是担心那些蔬菜们……\n没法一直照顾它们的话……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "共鸣！你们的担忧，我完全理解！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "不过，无需担心！在你们不在的时候，\n我们会替你们照顾蔬菜的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "诶！？那不会太辛苦了吗！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "我也会帮忙的。\n如果只是这点面积，应该没问题。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯！而且，\n我还准备了一个秘密武器！跟我来！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "被引导到的地方，停着一辆极具未来感的车。\n……轮子被喷射装置取代了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "这就是为你们准备的机器……蔬菜喷射号！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "这是将成熟的蔬菜以超高速送到\n你们合宿所的超级机器！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "哇哦！这真是太厉害了，理事长！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "因为还是1号机，效果可能会不如预期，\n但这可是世界首创！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "这是专门为去合宿的你们开发的\n划时代机器！哈哈哈！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "……又是用私房钱买的奇怪东西……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "不、不是的！这可是绝对必要的开支！\n完全是为了学生们……",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "总之，感谢秋川理事长她们，\n合宿期间也不用担心田地了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008010.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008010.json
@@ -1,0 +1,74 @@
+{
+  "Title": "试作！研究的成果！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "哇～！这次的蔬菜也长得很好呢～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "是啊！这样的话……嗯——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "啊！你刚刚在想做什么料理吧～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "被，被发现了吗？\n最近这种事情已经变成习惯了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "如果是我的话，试着用大蒜做拉面吧。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "嘿嘿，反复在试作的可不止是小花和菱曙哦？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "如果是我，会做披萨和麻婆豆腐！\n一切皆有可能！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "草莓冰淇淋也不错呢。\n嘿嘿……。",
+      "ChoiceDataList": [
+        "也差不多该再开一次试吃会了吧",
+        "也差不多该再开一次试吃会了呢"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "是啊！想试试自己能做到什么程度了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "好！大家开始做料理吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008011.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008011.json
@@ -1,0 +1,59 @@
+{
+  "Title": "大饱腹！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "啊～啊……！这次也非常好吃！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "炖菜、拉面、披萨、麻婆豆腐，\n还有冰淇淋……每样都很满意！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "嘿嘿……\n其实这次，为了增加恢复疲劳的效果，\n我做了一些调整。毕竟是干完田地活之后嘛。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "哦，厉害啊。这次的经验派上用场了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "是的。\n波旁和小特同学的事情让我学到了很多。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "料理的力量，和食物的相处之道……\n感觉有点明白了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "哦～！今后也是不断尝试和美味！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "蔬菜种植和料理都要一起努力啊。\n吃饱了，再干一会儿吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008012.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008012.json
@@ -1,0 +1,47 @@
+{
+  "Title": "饱腹！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "我吃饱啦！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "这次也很美味啊……！嘿嘿……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "是啊，味道很好。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "接下来……\n如果还能考虑到营养价值就完美了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "不过已经很美味了，所以没问题！\n这次就算成功吧？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "不论是料理还是种菜，都要一步步来。\n好，那就再加把劲吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008013.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008013.json
@@ -1,0 +1,549 @@
+{
+  "Title": "开宴！美食发布会！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "独白",
+      "Text": "有一天，和往常一样在田里忙碌时，\n秋川理事长来了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "大家好，各位！\n和往常一样种出了很好的蔬菜啊！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "啊，您好！\n理事长您也来干农活吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "呵呵，虽有一部分是这样，\n但我还有一件事想拜托你们！",
+      "ChoiceDataList": [
+        "什么事呢……"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯，\n各位这一年来在美食方面表现得非常出色。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "受你们的影响，\n其他同学中也开始有人学习美食了。\n这是很好的趋势！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "所以，举办！\n第一次学园美食发布会！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "这是一个让在一线辛勤耕耘种菜的学生们\n展示自己倾注心血的料理的活动！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "让同学们广泛了解美食的力量！\n希望你们也能参加！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "大家做的美食聚在一起的发布会……\n感觉会很有趣～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "是啊。\n而且我们也一直有在认真举行试吃会！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "想把我们学到的成果展现给大家……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "米浴也希望大家能知道我们一起种的\n蔬菜的美味……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "其他同学会拿出什么样的料理呢……！\n我的肚子……不，胳膊已经迫不及待了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯！我相信你们一定会这么说！\n那么，我期待着你们的表现！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "独白",
+      "Text": "就这样，发布会的准备开始了。\n大量的蔬菜，还有新菜单的披露。\n其中最积极的是——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "——大家～！我送来慰问品了哦～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "哇～！？好多料理啊～～～～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "因为现在是寒冷的季节嘛～。\n有暖暖的炖菜、咖喱。拉面，还有加了很多辣椒\n的麻婆豆腐！请大家享用吧～！",
+      "ChoiceDataList": [
+        "好丰盛啊……！",
+        "真丰盛呢……！"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "发布会可是很难得的机会嘛☆\n希望更多的人能品尝到各种美食！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "话说回来，\n从明天起我要出发旅行一段时间！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "诶！？要、要去哪儿！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "主要是去寻找能最好地衬托我们种的\n蔬菜的食材！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "所以，我会去山啊河啊还有海边之类的☆\n去那些熟悉的美食圣地～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "独白",
+      "Text": "……我知道她不想妥协。\n但监护人也是必要的，所以自己也跟着冒险了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "哦，看到了伞菌！\n它和意大利面最配了☆\n当然和蔬菜也是绝配！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "蘑菇能强健骨骼，\n对我们赛马娘再合适不过了！\n继续前进吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "越过山越过海越过峡谷～♪\n美味的汤在哪里～♪",
+      "ChoiceDataList": [
+        "发现海带！"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "哦～太好了☆\n今天是矿物质丰收的一天！\n做成盐渍海带，当做训练时的补给正合适！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "哈哈～，找到了很多好食材呢～。\n学园的同学们一定会惊讶的～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "蘑菇和富含钙的蔬菜搭配，\n做成防止受伤的菜单也不错。\n盐渍海带可以做成沙拉～。",
+      "ChoiceDataList": [
+        "很有想象力啊",
+        "很有想象力呢"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "是吗？\n呵呵，看来对食材的看法也在改变呢～。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "——这种想象力！不妥协的行动力！\n真是太棒了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "诶～，理事长！？您怎么会在这里！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "哎呀，虽然很辛苦……！\n但有些东西早早交给你们比较好！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "这只是个提示……\n但我相信你们一定会取得优秀的成果！\n拜托了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "独白",
+      "Text": "随着发布会的临近，\n学园的参与者们为了展示料理而进行着激烈的比拼——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "待兼诗歌剧",
+      "Text": "做好了哦～！\n待兼家特制，鸡肉炖菜工作餐完成了～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "待兼"
+      ]
+    },
+    {
+      "Name": "待兼福来",
+      "Text": "然后，再加上这个秘传的祈祷——\n营养多多，蛋白质多多……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "森林宝穴",
+      "Text": "吃下这个吧！这是我的拿手绝活——\n我罗武魔娑螺天顶火零啊——！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "青竹回忆",
+      "Text": "什么！？我的……\n漩涡火焰拉面的气场，被香料的香气吞没了！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "森林宝穴",
+      "Text": "嘿嘿——\n发布会的焦点，我就靠这个拿下了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "独白",
+      "Text": "然后——终于到了发布会的日子！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "那么，开会！\n大家，请尽情展示你们骄傲的蔬菜吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "鹤丸刚志",
+      "Text": "哇，摆满了料理……！\n啊，还有制作者的名牌。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "樱花千代王",
+      "Text": "……咦！？\n这张桌子上的，还有那边，那张桌子的料理，\n全都是……同一个名牌！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "呵呵呵，没错！\n这些都是我们的料理哦～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "比如，那边的料理是给短距离选手准备的！\n特制咖喱里含有适量的蛋白质和糖分，\n满足爆发力的需求！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "诶！？那，长距离适性的料理也有吗！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "啊，那就请尝试这道富含铁质的蔬菜披萨吧！\n里面有去油的金枪鱼和蛤蜊哦！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "还请看一下食谱！\n上面还写了用餐时间和生活节奏的安排……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "樱花千代王",
+      "Text": "嗯嗯……这个必须要记笔记！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "樱花千代王",
+      "Text": "不过话说回来……不仅质量高，\n还这么丰富多样，真是想不到啊。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "嘿嘿……\n回想起来我们这一年真的学了很多东西。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "是啊。从波旁同学的事情开始——\n我们学到了跑步和吃饭有很深的关系。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "不仅是身体，连心灵也要得到满足。\n也感受到了美食的深奥。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "所以，想让大家品尝到我们全部的美味～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "我们品尝大家做的美味，大家品尝我们的美味！\n互相学习美味——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "大家都能做出更美味的东西！\n在比赛中也能全力以赴！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嗯！这次的发布会，\n就像是大家一起做的相扑火锅一样☆",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "小栗帽",
+      "Text": "什么！？原来如此……！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "玉藻十字",
+      "Text": "别从字面上理解啊！\n不过菱曙你真有豪气……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嘿嘿。因为这不仅仅是我们的心意。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "其实呢……\n理事长把同学们的烦恼都记在了笔记本里！\n为了制作料理而告诉我们了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "学生们",
+      "Text": "啊，理事长！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "学生们",
+      "Text": "啊……我也记得我填过问卷！\n烦恼也被认真听取了……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "咳、咳……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "那、那么。\n这次的发布会的目的！\n已经由菱曙同学完美地表达了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "菱曙"
+      ]
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "从大家的脸上可以看出，\n大家从互相的料理中受到了很大的启发，\n对美食的热情更加高涨！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "鹤丸刚志",
+      "Text": "我也想做……！能打造强壮身体的料理！\n好，我要加油了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "东海帝王",
+      "Text": "让帝王大人的招牌蜂蜜运动饮料\n在学园里流行起来！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "帝王大人"
+      ]
+    },
+    {
+      "Name": "鲁道夫象征",
+      "Text": "嗯。我出品的『加了高野豆腐的炖菜』\n也还有改进的空间。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "鲁道夫象征",
+      "Text": "“不是只有羊羹才有营养价值”\n——我会更加努力钻研的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……多亏了大家种的蔬菜，\n学园里的疾病和受伤的情况都在减少。\n统计数据也清楚地显示了这一点！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "作为理事长，真心感谢！\n希望你们能继续努力！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "最后，我要表达谢意！\n—菱曙，拜托了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "好—！那么大家！\n把你们的蔬菜都放进这个大锅里吧～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "青竹回忆",
+      "Text": "诶？为什么？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "哈哈～这是最后的环节！\n把大家的美味合在一起！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "好！\n学园里的美味相扑火锅炖菜完成了～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "大家请在这里排队！\n有盛菜的盘子哦！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "小心不要洒出来……啊啊，好香～……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "大家",
+      "Text": "我开动啦～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "大家",
+      "Text": "好美味～……！\n每一口都让全身暖和起来……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "呵呵，当然啦☆\n这是集合了大家的美味的百倍美味火锅！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "今后大家也一起做更多美味的东西吧！\n让学园充满美味！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "独白",
+      "Text": "于是，发布会在一片欢声笑语中结束了——\n这成为了学园中美食热潮的开端。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008014.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008014.json
@@ -1,0 +1,76 @@
+{
+  "Title": "到来！美食热潮！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "富士奇石",
+      "Text": "看，这是栗东宿舍的大家一起种的\n富含蛋白质的胡萝卜。\n这个胡萝卜蜜饯很受欢迎哦。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱亚马逊",
+      "Text": "确实是不错的蔬菜，\n但我们宿舍的草莓也不逊色。\n这些草莓冰激凌在宿舍里可是大受好评的呢！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "美妙姿势",
+      "Text": "每天让大蒜闻到拉面的香味，\n就能培养出更适合拉面的大蒜！\n这就是大蒜增量农业法哦，神宫！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "神宫"
+      ]
+    },
+    {
+      "Name": "空中神宫",
+      "Text": "……这是哪来的逻辑啊……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "最近，\n学园里到处都是关于料理和蔬菜的讨论……\n完全进入了美食热潮呢！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "而掀起这个热潮的……可以说是我们了吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "菱曙同学真是大显身手了！\n那个炖菜的味道，真是让人难以忘怀……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嘿嘿～。今后也请期待哦！\n我会做出更多更美味的料理的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "……作为食物风潮的先驱者，\n我们要继续加油呢！",
+      "ChoiceDataList": [
+        "那就再举办一次试吃会吧！",
+        "那就再举办一次试吃会吧！"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "好啊！那就再试一次吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008015.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008015.json
@@ -1,0 +1,79 @@
+{
+  "Title": "大成功！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "哎呀～！这次也吃得好饱！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "真厉害……比发布会的时候还要美味……！\n米浴的眼泪都快流出来了……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "好、好可怕……！\n我们究竟还能做到多美味呢……！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "嗯嗯。\n大家的料理都给了我们很大的启发呢……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "营养学的学习也完全掌握了～\n训练效果也是绝佳的哦～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯，了不起！\n真是花果兼备的料理！",
+      "ChoiceDataList": [
+        "理事长！？"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "哈哈哈，失礼了！\n关于前几天发布会的事，\n我想再一次表达感谢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "多亏了你们，\n学园学生对饮食的意识有了显著提升！\n真的，非常感谢！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嘿嘿～没那么夸张啦☆",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……或许我们可以考虑一下下一步了――",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……总之！今天多谢款待！\n今后也请继续努力吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008016.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008016.json
@@ -1,0 +1,79 @@
+{
+  "Title": "成功！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "啊～今天也吃得好饱！\n谢谢款待！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "今天也做得很好呢！\n让我想起了发布会的情景。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "不过，其他人的蔬菜和料理，\n质量也在不断提升啊。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嗯……\n为了保持冠军地位，练习不能懈怠啊！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "嗯……米浴，要成为冠军！\n……啊，不，不是说吃太多变胖哦！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "不，真是了不起！\n看得出你们没有懈怠啊！",
+      "ChoiceDataList": [
+        "理事长！？"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "哈哈哈，失礼了！\n关于前几天发布会的事，\n我想再一次表达感谢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "多亏了你们，\n学园学生对饮食的意识有了显著提升！\n真的，非常感谢！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "嘿嘿……没那么夸张啦。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……或许我们可以考虑一下下一步了――",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……总之！今天多谢款待！\n今后也请继续努力吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008017.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008017.json
@@ -1,0 +1,277 @@
+{
+  "Title": "告知！超级美食活动！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "训练员",
+      "Text": "――好嘞！\n最后三组轮胎拖曳比赛！能行吗！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "是！还行！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "独白",
+      "Text": "某天，在学园的看台上——\n秋川理事长正静静地注视着正在训练的学生们。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……哦呀！是你呀！\n你总是和学生们一起努力呢！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "你们的队伍对学校的饮食做出了很大的贡献。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "真是佩服！虽然有点晚了，\n但作为理事长还是要感谢你们！\n你们这样的人才是学园的支柱！",
+      "ChoiceDataList": [
+        "理事长才是！"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "不不。我只是提供了一个机会。\n你们自学了很多，积累了知识和经验。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……想为学生的健康作出贡献。\n我只是这样想着才开放了农田——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……嗯？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "训练员",
+      "Text": "——明天就是正式比赛了。\n你准备好了吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "……能做到的。\n为了这一天，我们一直在准备着。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "过去那个……老是受伤、\n动不动就放弃一切的我，已经不复存在了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "训练员",
+      "Text": "……嗯。你真的变了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "那一天，感觉已经是很久以前的事了。\n我们两人第一次拿锄头开垦那块地的日子。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "当时觉得这真是傻事。\n觉得……食物怎么可能改变什么。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "…………。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "但既然是自己种的，就得吃啊……\n也开始每天吃训练员准备的补食。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "……我想真的是有改变的。\n骨头变得更强壮了，肌肉也变得更加明显了，\n能够以最好的状态参赛。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "生活也变了……心态也变了。\n只要不放弃，我也一定能实现梦想。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "明天……我想去证明这一点。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "训练员",
+      "Text": "……嗯！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "…………。嗯……嗯。",
+      "ChoiceDataList": [
+        "……开放农田真是太好了呢"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……是啊。\n能够帮助学生，这一点对我来说就已经——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……但是，还不够。\n如果食物能够帮助学生，\n我希望将这一圈子不断扩大。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "…………。其实我有一个一直在筹备的计划。\n不久的将来，我会找机会告诉你的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "独白",
+      "Text": "随后，农田如往常一样，热闹非凡。\n然后——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "……哦？大家，理事长来了！\n您好！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "您好～！理事长～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯！大家辛苦了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "今天……我有一个请求！\n还记得之前的发布会吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "当然！\n自那以后，来农田的孩子们越来越多了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "这说明大家开始关注饮食了呢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯，正是如此！因此——\n我现在打算举办一个更大规模的活动！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "全校学生，所有年级一起参与的，\n迄今为止的集大成的活动——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "命名为——『特雷森大丰食祭』！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "特雷森大丰食祭"
+      ]
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "食物。以及与之相关的知识。\n我要将这些以最好的方式提供给学生们！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "而且——\n在那里提供的食材，就用你们种植的！\n我认为没有比这更好的选择了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "草上飞",
+      "Text": "理事长亲自出马，全校都参与——\n这将是一个非常大的活动呢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "神鹰",
+      "Text": "神鹰的超级辣料理会喷火的哦！\n我会种很多辣椒参战的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "神鹰"
+      ]
+    },
+    {
+      "Name": "西野花",
+      "Text": "自发布会以来，我们也做了很多新菜品……\n如果能再磨练一下，\n或许能做出让大家惊艳的料理呢……？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "总、总觉得，好兴奋啊……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯，嗯……！\n虽然我可能会因为活动的准备而忙碌，\n但只要有时间我还是会来参与农田工作的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "大家，一起流汗……加油吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008018.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008018.json
@@ -1,0 +1,97 @@
+{
+  "Title": "进行！活动准备！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "圣王光环",
+      "Text": "哈！哈！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "川上公主",
+      "Text": "哇哦，这是一流的挖掘技术啊！\n简直和公主动力铲有的一拼！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "青云天空",
+      "Text": "嗯，真是精彩。\n青云家的锄头挥舞术，授予你五段资格吧。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "圣王光环",
+      "Text": "……不，等等！？\n青云天空同学你不要像个师傅一样站在那里，\n也来帮忙！你农家的自尊心呢！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "青云天空"
+      ]
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "哎呀哎呀，这块田地越来越热闹了啊。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "千明代表",
+      "Text": "大家都在考虑着理事长发起的活动呢。\n我也很期待。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "是啊……\n话说回来，千明，你也会来农田工作啊……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "千明代表",
+      "Text": "嗯。很有趣呢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "不过，真不知道会是个什么样的活动呢！\n我最近总是梦到它！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "嗯……\n上次的发布会就很精彩了，这次会怎么样呢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "大家的营养学知识也在不断加深……\n这方面也会有相当高的水平……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "比那次还要棒吗……真让人期待啊～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "这下可不能掉以轻心了。\n不仅要种好蔬菜，料理也要做得好才行。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "好！我们再来一次试吃会吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008019.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008019.json
@@ -1,0 +1,65 @@
+{
+  "Title": "准备万全！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嗯～，非常棒！大家觉得怎么样？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "是的，这样的话……！\n一定会在活动举行时大受欢迎的吧。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "只要这个一展出，\n理事长也一定会大吃一惊的～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "理事长……对啊！\n想让理事长也尝一尝！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "明明很忙，却总是来田地里。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "对啊。也想让她高兴起来。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……嗯！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……打了个盹。这可不行。\n明明还有很多活动准备要做。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（普通事务也不能耽误。\n现在还在努力种菜的学生们——\n加油！鼓劲！）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008020.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008020.json
@@ -1,0 +1,71 @@
+{
+  "Title": "准备完成！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "我吃饱了～！\n大家觉得怎么样呢？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "质量相当不错！\n在正式活动中也一定会得到好评吧。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "不过，其他队伍的大家也会做出很棒的料理吧！\n……流口水。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "是啊。如果可以的话，\n希望能以超群的料理让理事长大吃一惊。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "理事长……对啊！\n想让理事长也尝一尝！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "明明很忙，却总是来田地里。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "对啊。也想让她高兴起来。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……嗯！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……打了个盹。这可不行。\n明明还有很多活动准备要做。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（普通事务也不能耽误。\n现在还在努力种菜的学生们——\n加油！鼓劲！）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008021.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008021.json
@@ -1,0 +1,343 @@
+{
+  "Title": "夙愿！我的梦想！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（那么……备品、设备的订购暂时告一段落了。\n毕竟是处理食物……\n必须做到万无一失——）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……呼……",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "理事长……稍微休息一下如何？\n毕竟还要并行处理正常业务，\n会不会太累了……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……嗯～……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……不行！\n就在这一刻，还有人在工作！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "好，看好了哦？\n要从多功能膜上给蔬菜浇水的时候，\n就这样在洞里——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "嗯嗯，没问题的小特同学。\n我已经习惯这种农活了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "哈哈……。\n大家有了经验，已经变得非常可靠了。\n那么，我也开始吧——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……嗯？哎呀……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……不行不行。\n这样的话就不能作为理事长树立榜样了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "双涡轮",
+      "Text": "……咦？理事长好像在摇晃！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "优秀素质",
+      "Text": "等，等一下！？您还好吗！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "不，不，不用担心！只是有点头晕——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "不，我很担心！\n等出了什么事再后悔就晚了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "好，大家！把理事长抬到树荫下去！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "大家",
+      "Text": "一二三——！！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "哇哦！？\n高度！漂浮！神轿！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "然后——\n大家一起把秋川理事长抬到了树荫下。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "哎呀，惊讶！\n没想到竟然能这么轻松地抬起来！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "对、对不起……。\n大家都很担心理事长。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "不不，放心吧！\n那样的力量，正是营养充分的证明！",
+      "ChoiceDataList": [
+        "身体还好吗？"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯。托大家的福，没问题。……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "……怎么了？\n果然还是不舒服吗……！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……那个。\n现在，你……幸福吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "诶？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "好好奔跑，好好学习，好好摄取营养……\n能够幸福地过着学园生活吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "身心健康——追逐着自己的梦想吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "……当然！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "虽然有时也会很辛苦……但我喜欢跑步。\n我想……一直都会是这样！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……这样啊。那就好。……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "到目前为止，我看过很多学生离开了学园。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "当然！竞争的世界是残酷的。\n虽然产生失败者令人心痛，\n但这也是运动员的现实。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "但是……疾病。伤痛。\n梦想因此受阻的学生，\n我也见过无数个……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……无论经历多少次，我都无法习惯。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "至少在学园生活中，\n希望你们不要忘记奔跑的快乐。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "为了这个，我唯一能做的，\n就是关于饮食的举措。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "保持强壮健康的身体——不，不仅仅是这样。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "提供持续奔跑的活力，\n让你们无论多少次都朝着自己的梦想前进——\n我想要这样的食物。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "……理事长。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "举行大丰食祭也是出于这种心情。\n如果饮食能对你们的梦想有一点帮助，\n我就会不吝努力。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……希望你们能一直快乐地奔跑。\n虽然这可能有些自私……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……但这是我唯一的梦想。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……。不，抱歉！说的太多了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "今天我会乖乖回到办公室工作。\n那就这么说吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "…………。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "……这样啊。理事长说了这些话。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "……我在想，虽然要为活动努力——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "但能不能为了回报理事长……\n大家一起做点什么呢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嗯！回报理事长的恩情，对吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "我完全赞成！\n要好好回报食物的恩情！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "在场的学生们都纷纷表示赞同。\n这样的声音如波纹般逐渐扩大。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "但是……以什么形式回报最好呢？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "这就需要大家一起去想了。\n要给予丰厚的回报！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "不过，暂时……这事要对理事长保密！\n惊喜会更好吧？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "关于如何回报秋川理事长——\n暂时，大家决定解散。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008022.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008022.json
@@ -1,0 +1,706 @@
+{
+  "Title": "各自的“美食”",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "为了探讨报答秋川理事长的方法，\n同学们在田地里聚集，提出了各种意见——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "嗯，果然还是“美食”最合适呢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "对啊！本来就是因为理事长，\n学园的食物才如此丰富多彩！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "用美味的食物报答美味的恩情！\n我觉得这才是最好的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "虽然我们也要认真准备大丰食祭，\n但作为报答的料理一定要靠大家一起\n齐心协力来完成！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嗯！把大家的力量集中在最棒的料理上，\n给理事长注入“美味力量”吧～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "如果有好的点子，请尽量分享……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "米浴也会拼命想办法的……！\n大家，加油……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "于是，大家齐心协力，\n为秋川理事长制作出了一道终极料理。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "——今天有点空闲。\n去给正在为菜单努力的同学们帮帮忙吧。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "或者，也可以去找秋川理事长，\n顺便问问她喜欢的食物。\n那么，该去找谁呢——",
+      "ChoiceDataList": [
+        "葛城王牌",
+        "特别周",
+        "西野花",
+        "菱曙",
+        "米浴",
+        "秋川理事长"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "我决定去帮葛城王牌。那么，她会在哪里呢——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "葛城王牌"
+      ]
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "——哦！训练员先生啊！\n我正在查看蔬菜的状况。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "嘿嘿。虽说料理也不错，\n但我最擅长的果然还是种菜呢！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "如果可以的话，\n能帮忙看看那边的新辣椒吗？\n差不多该搭架子了。",
+      "ChoiceDataList": [
+        "知道了！"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "农田里的蔬菜是制作菜单的根本。\n和葛城王牌一起大汗淋漓地努力照顾\n蔬菜们——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "呼——！\n不好意思啊，训练员先生！\n让你陪到了最后。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "看啊。\n多亏了你，这些蔬菜看起来都精神多了吧？",
+      "ChoiceDataList": [
+        "一定会结出美味的果实的",
+        "一定会结出美味的果实的"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "嗯。最好的料理需要最好的蔬菜作为基础。\n……拜托了啊，蔬菜们！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "……不知怎么的，我觉得自己越来越像家父了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "和蔬菜说话的习惯也是从父亲那学来的——\n合宿的时候，对米浴她们说的话，\n其实也是引用的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "『平时投入多少精力，蔬菜就会有多少回应』。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "『要对食物心怀感激，\n吃东西前要讲“我开动了”』。\n这听起来像老生常谈，但——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "……在和这些蔬菜面对面的过程中，\n我觉得自己终于理解了其中的意义。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "它们健康成长，才让我们能健康地享用。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "“食”确实是建立在对食物的感激上的。\n…………。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "——谢谢你们。\n希望你们能以最好的形态成长。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "我们也会以最好的方式享用你们的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "和葛城王牌一起，再次感受了“食”的深刻意蕴。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "我决定去帮特别周的忙。\n那么，她在哪里呢——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "特别周"
+      ]
+    },
+    {
+      "Name": "特别周",
+      "Text": "啊，训练员先生！真巧啊！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "我正要去街上为了菜单参考进行\n美食巡游调查呢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "……真的是调查哦？真的。\n而且没关系，今天是我的放纵日！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "那么，先去这家店吧！\n我最喜欢这家店的味道了！\n一定能为菜单提供灵感——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "饮食店的客人",
+      "Text": "！？不，不妙！\n“无底之腹的Special”来了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "饮食店的店长",
+      "Text": "快煮新米！一会儿就会被吃光的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "哎，哎！？等，等一下，这是误会～！\n今天我是来学习这家店的美味秘诀的——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "……虽然有点小插曲，\n但调查还是进行得很顺利——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "啊～一度以为要出大事了，\n不过店里的大家给了我很多建议，\n这次调查很有意义呢！",
+      "ChoiceDataList": [
+        "可以作为调味的参考啊",
+        "可以作为调味的参考呢"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "嗯，是这样的……\n不过，我觉得重新学到了重要的事情。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "“想让吃料理的人满足”。\n这种心情，蕴含在每道菜中。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "……回想起来，当时的理事长也把这种心情\n传递给了我们。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "对我来说，果然“食物”就是——满足！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "能让心灵也满足的料理！我要以此来回报理事长！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "通过调查，\n特别周更加明确了自己想要传递的心情。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "我决定去帮西野花。那么，她在哪里呢——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "——啊！训练员先生，你好！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "啊……我身上是不是还留着咖喱的味道……？\n刚才一直在做菜。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "虽然之前学会了很多……\n但要把“最好的料理”总结成一道菜……\n还是很难找到答案。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "最好的健康食品……\n而且还是最美味的料理，\n应该是什么样的呢……？",
+      "ChoiceDataList": [
+        "好难啊……",
+        "好难呢……"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "——啊！找到你了，花同学！\n好像有你的包裹哦！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "诶？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "……！是妈妈……！\n上次在电话里和她商量了菜单的事……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "『——妈妈会把你小时候的食谱笔记送来。』",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "『虽然算不上出色，但希望对你有帮助。\n加油 母亲』……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "西野花的母亲所写的食谱。\n那是一本零零散散，乍一看有些不成样子\n的笔记——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "引人注目的是——\n那上面记录了女儿喜欢的零食、\n身体不适时的养生料理等。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "从反复试验、改写的痕迹来看，\n其中饱含着母爱。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "…………！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "…………。\n我好像在为没必要的事情烦恼。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "只要用心想着理事长最喜欢的料理，\n努力去做就好。\n……就像妈妈为我做的那样。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "“食物”就是心意。\n……谢谢你告诉我，妈妈。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "从母亲的礼物中，西野花得到了重要的启发。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "我决定去帮菱曙。那么，她在哪里呢——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "哦～训练员先生！你好～☆",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "现在呀～我正在给大家做相扑火锅～。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "仔细一看，旁边有移动炉和大锅，\n还有一堆食材——\n于是我决定帮忙切材料。",
+      "ChoiceDataList": [
+        "你打算用火锅作为特别菜单吗？",
+        "特别菜单也打算做火锅吗？"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嗯～，也有这个考虑……\n但最近我想更深入地研究火锅呢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "我觉得，理事长她啊。\n就像是相扑火锅一样。",
+      "ChoiceDataList": [
+        "……诶？"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "理事长的愿望，\n是希望我们能一直健康地跑下去吧？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "理事长……\n就像是让我们一直全力以赴的火锅！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "所以呢，我的梦想和理事长是一样的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "我也想做出让理事长一直全力以赴的料理！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "对我来说，“食物”的意义就是——\n不管什么料理，都得是“相扑火锅”！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "所以，我想从基本的相扑火锅开始考虑菜单～。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "并跑后的马娘们",
+      "Text": "唔～，累死了～……！\n……嗯？好香的味道……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "大家辛苦了～☆\n来来，吃吧，吃吧～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "“食物就是火锅”……\n菱曙那坚定不移的信念，\n就像相扑高手的肢体一般坚不可摧。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "我决定去帮米浴。那么，她在哪里呢——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "啊！嘿嘿，你好。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "那个，餐厅的人借给我厨房，\n让我试着做了一些菜。\n像是咖喱和拉面之类的。",
+      "ChoiceDataList": [
+        "有什么能帮忙的吗？",
+        "我能帮你什么忙吗？"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "可、可以吗？\n那，那个……能帮我试吃一下吗……？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "哇～！谢谢！\n愿意全都吃一遍……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "嘿嘿……最近米浴真的很开心呢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "不管是料理，还是米浴自己，\n都能让大家感到幸福。",
+      "ChoiceDataList": [
+        "因为你一直在为之努力啊",
+        "因为你一直在为之努力呢"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "……理事长说过的话，米浴很能理解。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "……希望我们大家一直健康地跑下去。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "希望我们一直幸福下去……这样的心意。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "米浴……想用料理来回报这份心意。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "吃了之后能从心底感受到幸福的“食物”——\n我想送给理事长。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "……虽，虽然这么说，\n但还是没什么自信……嘿嘿。",
+      "ChoiceDataList": [
+        "你一定可以的！"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "真的吗……。……对呀。\n就算米浴做不到……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "还有一起做料理的大家呢！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "米浴眼中发出光芒——\n通过参与食物的制作，她获得了真正的坚强。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "我决定去秋川理事长那进行调查。\n虽然是为了惊喜，但要小心别让她发现——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "唔嗯？我的喜欢的食物吗？",
+      "ChoiceDataList": [
+        "想吃的东西，或者回忆中的味道"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯……我最喜欢寿司——\n但最近才吃过。\n平时多是会餐或者简单的快餐，不过——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "——对了！说起回忆的味道，\n我有一次和手纲去了家庭餐馆。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "一看到菜单，我就点了儿童套餐……\n那味道至今难忘！",
+      "ChoiceDataList": [
+        "真的那么好吃吗？"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯。味道当然很不错——\n但你仔细思考一下。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "儿童套餐和这所学园——是不是很相似？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "汉堡、意大利面、炸虾、炒饭——\n每一样都是主角级的料理！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "然而，它们却能在一个盘子上共同存在，\n交相辉映。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "这正如学园里许多学生在各自舞台上的碰撞——\n我这么认为！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "因此，每次看到儿童套餐，\n我都会重新坚定决心。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "就像星星闪耀般，给更多学生提供表现的机会——\n这就是这所学园应有的样子。",
+      "ChoiceDataList": [
+        "原来如此……！"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "本以为只是喜欢而已，但却有着这样的缘由——\n我再次感受到秋川理事长的伟大。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "还有那插在炒饭上的小旗子！\n真是让人心情激动！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "……果然，也许真的只是因为喜欢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008023.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008023.json
@@ -1,0 +1,489 @@
+{
+  "Title": "百感交集！学生们的心意！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "独白",
+      "Text": "某天，经过理事长室时，\n听到了秋川理事长的声音。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……好！—不，手纲也真的辛苦了。\n终于——终于，完成了……——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……哦，是你！\n好消息……活动的准备终于基本结束了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯……！真的很期待那一天……。",
+      "ChoiceDataList": [
+        "……有点累了吧？"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "哈哈，不不。\n越过了山峰，可能有点放松过头了。\n不行啊，正戏还在后面呢……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……可以想象到。\n学生们……开心的样子……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "——理事长？理事长！？\n不、不好了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "理事长……倒下了！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "现在在保健室休息……没事吧！？",
+      "ChoiceDataList": [
+        "恐怕是劳累过度了……",
+        "恐怕是劳累过度了……"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "……本来就那么忙，还要准备活动……\n而且还帮我们做农活。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "理事长……真的拼尽全力了啊。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "为了我们——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "……理事长。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……希望你们能一直快乐地奔跑。\n虽然这可能有些自私……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……但这是我唯一的梦想。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "…………。",
+      "ChoiceDataList": [
+        "……现在，是回报的时候了！",
+        "……现在，是回报的时候了！"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "……嗯！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "是啊。虽然原计划是在活动当天，\n现在学生们都还在准备。……能行吧？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "当然！\n此时不拼，更待何时！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "虽然还在试作阶段……\n但我们会用大家的心意来完成的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "好～！我去叫其他人来！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "八重无敌",
+      "Text": "嗯嗯！这根胡萝卜……斗气十足！\n一定能为理事长补充营养！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "稻荷一",
+      "Text": "这是个大土豆啊！\n一定能补充体力！一起挖出来吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "小特，训练员先生，帮我一把！\n来，一、二！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "一、二！",
+      "ChoiceDataList": [
+        "嘿咻！"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "（对啊。最开始合宿的时候……\n理事长也帮了我们很多）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "（一起吃过的饭的味道，永远不会忘记……\n请等着我们……理事长！）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "目白赖恩",
+      "Text": "嗯！必杀蒜泥！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "目白多伯",
+      "Text": "这、这边，胡萝卜和土豆的皮都剥好了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "谢谢！准备好胡萝卜，然后……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "切菜就交给我吧！\n米浴，已经很熟练了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "切好的蔬菜可以直接放进锅里～！\n一起料理～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "（把让心灵和身体都能感到美味的料理！\n回报给理事长！）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "（多亏了理事长，\n我们真的学到了很多关于饮食的知识……！）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "（理事长一直……在为我们着想……！）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "（要传达……给理事长……！）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "（我们大家的……心意！）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……嗯……？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "理事长，醒了！？太好了……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "手纲……是吗。我……倒下了吗。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……不行啊，现在身体起不来。\n想让学生们保持健康，自己却倒下了，\n真是丢人啊……哈哈。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "您太勉强自己了。……\n不管怎么样都不听劝啊。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……恐怕没法出席大丰食祭了。\n不过……准备都完成了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "这样就好。为学生们创造了接触美食的机会。\n我……很满足了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "…………。理事长就是这样的人呢。\n……不过。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "……学生们一定会难过的。\n如果理事长不能露面的话。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "…………。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "那个……理事长在吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯……！……手纲。扶我起来。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "理事长……身体还好吗？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "啊，没事的。\n能这样坐起来就说明没问题了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "只是……当天，可能无法指挥运营。\n需要依靠你们和手纲……对不起。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "……理事长。\n其实……有东西想请您收下。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……？说起来，刚才就闻到了一股……\n很香的味道——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "这是……好豪华的料理！\n这真的是你们做的……？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "虽然您的身体还不舒服……\n但，哪怕只吃一口。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……明白了。那我就尝尝！\n不仅仅一口，要多吃几口！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（不过……现在的我，\n连味道都不一定能尝出来……）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……我开动了！…………。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "…………。\n……这……这……是什么……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "太好吃了！！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "这、这是什么味道！？\n仿佛电流般，让全身充满了活力……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "没问题了……\n出席大丰食祭简直小菜一碟！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "真的！？……太好了……！\n真的……太好了……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "我很感动！谢谢……！\n没想到你们学生们会为大丰食祭\n准备如此豪华的料理！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "……其实……\n这料理不是为了大丰食祭准备的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "是我们为了理事长准备的。这道料理。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "没错。大家一起讨论，齐心协力——\n终于得到了这个食谱。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "什、什么……！？你们为了我……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "不只是我们哟～！是所有学生们，大家～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "材料和烹饪方法都是仔细商量出来的呢！\n哎呀……还担心被理事长发现了呢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "…………！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "理事长，你曾经说过吧。\n希望我们大家能一直健康地跑下去。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "所以，我们也是一样的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "希望理事长能一直健康。\n这就是我们的愿望。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "…………。手纲。\n现在的我，真的……想一个人待会儿。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "不能在学生们面前流泪……\n我要控制不住了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "……不如就让她们看看吧。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008024.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008024.json
@@ -1,0 +1,254 @@
+{
+  "Title": "成功！食物的大祭典！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "独白",
+      "Text": "终于迎来了三年时间的里程碑——\n大丰食祭。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "这、真的没问题吗……？\n米浴，不会太显眼了吧……？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "有什么嘛～，你可是我们的看板娘哦！\n自信地去吸引视线吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "没、没什么奇怪的地方吧……？",
+      "ChoiceDataList": [
+        "完美！"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "哇～好可爱～！\n料理也准备好了，我们走吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "艾尼斯风神",
+      "Text": "今日限定！\n姐姐特制披萨！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "东商变革",
+      "Text": "数量有限的甜蜜魔法土豆汤！\n先到先得哦！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "小栗帽",
+      "Text": "不行……限定菜单太多了！\n我走右边！玉藻你走左边，\n把各队的料理都收集过来！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "玉藻"
+      ]
+    },
+    {
+      "Name": "玉藻十字",
+      "Text": "……你比比赛时还认真啊？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "从三明治到冰淇淋，应有尽有……！\n一定要尝一口！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "大份、特大份、超大份！\n根据你需要的营养，自由选择配料吧～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "之前我们为理事长准备的特别菜单也重制了！\n希望各位可以尝一尝……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "嗯……不愧是饮食潮流的先锋……！\n质量真高……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘B",
+      "Text": "之前的特别菜单也重制了……\n我当时负责剥胡萝卜皮呢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "盛况！绝赞！有王者风范！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "啊，理事长！身体已经没问题了吗……！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯，多亏了你们大家！作为证据——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（咕～）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "食欲全开！话不多说，我也来一份！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "当然啦！那么，首先——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "待兼诗歌剧",
+      "Text": "等一下！理事长请先品尝待兼家的秘传咖喱！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "目白光明",
+      "Text": "不不～。\n先尝尝多伯和赖恩姐姐特制的土豆汤。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": [
+        "多伯",
+        "赖恩"
+      ]
+    },
+    {
+      "Name": "爱丽速子",
+      "Text": "不，应该先品尝我的料理。\n我这一天特意准备了独门秘方。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "曼城茶座",
+      "Text": "……要给理事长吃的话，先用自己试试毒吧。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "唔，理事长真受欢迎……！\n这样的话，就只能通过比赛来决定\n先品尝谁的料理了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "无声铃鹿",
+      "Text": "！通过奔跑……！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "凯斯奇迹",
+      "Text": "哈哈，我完全同意这个结局……\n好啊。我们可是马娘嘛。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "目白阿尔丹",
+      "Text": "无论何时何地都在奔跑……这就是我们。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "好、好……！\n为了让理事长第一个品尝，米浴会努力的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "大家",
+      "Text": "哦～～～～！！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "哈哈哈！大家都很有精神，非常好！\n……真的。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……不行啊。\n这样的话肚子里可能什么都吃不下了。",
+      "ChoiceDataList": [
+        "诶？"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……大家都在健康地奔跑。\n我的梦想，现在就在眼前。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "仅此而已，我——…………。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "哎呀，不行！赢了之后，\n我什么都吃不下的话，那就太让人失望了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "那么……好！\n我也跑起来，让肚子饿了再说！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "各位！让我也加入你们吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "独白",
+      "Text": "然后，秋川理事长也加入了奔跑的马娘们。\n她们的脸上有着明朗的笑容，\n充满发自内心的愉悦。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "独白",
+      "Text": "无论何时何地，都能奔跑下去。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008025.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008025.json
@@ -1,0 +1,71 @@
+{
+  "Title": "超盛况！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "哇，卖光了～！\n材料全都用完了！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "诶，真的假的！？我们是最快的吧！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "啊，已经没有了吗！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘B",
+      "Text": "可惜……我好想尝一口这个……。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "——没事！没关系！\n我们还可以再做！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "是啊！田里还有很多正当季的蔬菜呢！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "稍等一下！\n我们会用超快的速度准备好的！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "训练员先生，麻烦看一下店！\n好，大家！出发！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "大家",
+      "Text": "哦～！！！！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "简直是，超盛况……！\n这次的活动成功地吸引了大量的人气，\n成为之后广为流传的佳话。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008026.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008026.json
@@ -1,0 +1,59 @@
+{
+  "Title": "大盛况！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "——这是最后一份了！\n大家，真的非常感谢！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘A",
+      "Text": "吃得好饱～！\n这里的东西果然是独一无二的美味啊！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "马娘B",
+      "Text": "嗯嗯！\n今后也很期待你们会做什么样的料理呢～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "哈哈，\n所有来的人都带着满意的笑容离开了呢！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "全部都被吃光了……！\n没有比这更高兴的事了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "这也证明了我们种出了这么好吃的蔬菜，\n还想出了很棒的料理方法呢。\n嘿嘿，我们真是饮食界的王牌啊！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "今后也要一直保持下去！\n冠军的宝座！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "在赞美声中，准备的料理全部被吃光了。\n对制作者来说，\n没有比这更令人满足的结果了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008027.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008027.json
@@ -1,0 +1,71 @@
+{
+  "Title": "盛况！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "……大丰食祭的也差不多要结束了呢。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "几乎都被吃光了，不过……\n还剩一点点材料。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "其他摊位的料理也都很好吃呢！\n我去探了探——真是惊喜！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "不过嘛，换个角度想想如何？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "大家心里也都这么想吧？\n……我们的料理看起来真好吃啊～。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "是，是的……！那是……！！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "葛城同学，你是心灵感应者吗！？\n认识了这么久才知道……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "那么，今天就到此结束吧！\n来做些美味的料理吧～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "大家",
+      "Text": "我开动了～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "料理几乎全部售罄。\n最后，大家愉快地度过了一个美味的时光。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008028.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008028.json
@@ -1,0 +1,189 @@
+{
+  "Title": "梦想就在眼前",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "呦，嘿……！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "好～！这边差不多了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "那边的土也快弄好了呢。准备播种吧。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "嗯！这次会长出什么样的蔬菜呢……嘿嘿。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "各位，早上好！\n一如既往地令人佩服啊！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "啊，是理事长！早上好！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯嗯，你们在大丰收祭上表现得非常活跃！\n我也很期待你们接下来会种出什么！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "嘿嘿，被这么夸奖，我更有干劲了！\n好，今天的农活也要加油了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "嗯……种子撒好了，水也浇了，\n草也拔了，地膜也铺了——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "……没、没事可做了！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "啊！？\n我、我还想展示一下我帅气的一面呢！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "嗯……想展示帅气的一面。\n但这里没事可做。那么——",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "……跑步如何？",
+      "ChoiceDataList": [
+        "忽然来这个！？"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "啊，不过不错哦！\n就当做早晨的训练吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "农活正好当做热身了，现在正合适。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "好，出发去跑道！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "嗯嗯……\n理事长，看看我们谁跑得最快吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "大家",
+      "Text": "出发～～～～！！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "啊呀，真有精神……真的。",
+      "ChoiceDataList": [
+        "是啊……"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "不过，非常好！作为马娘，\n当身体渴望运动时，不能停下脚步！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……看，她们……正满怀笑容地奔跑。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "喂，慢点慢点，别推！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "对，对不起！力气太大了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "嘿嘿。因为吃的很饱呢，小特同学！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "哈哈。米浴同学也是……。\n我、我也是。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "吃了多少就要跑多少！加油～加油～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（……不论何时，不论何地，永远奔跑）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（为了自己所见的未来。为了实现自己的梦想）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "（你们奔跑的每一步，都是我的梦想！）",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008029.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008029.json
@@ -1,0 +1,121 @@
+{
+  "Title": "理事长的工作",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "",
+      "Text": "虽然过去了三年——但有些日常仍未改变。\n今天也去学院的田地看看。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "哦，是你啊！今天也很努力啊！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "因为前几天的活动，\n学院的蔬菜几乎都被收获了，\n所以又从播种开始了。",
+      "ChoiceDataList": [
+        "和平常一样的工作啊"
+      ],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯。要有耐心和诚意。\n因为这就是培养的意义。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "……不过呢，\n即使是一样的工作，结果也会有很多不同。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "刚开始都是同样的种子。\n只要有丰富的环境，都会发芽。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "然后——最终会结出各种各样的果实。\n各具特色，每一个都很棒。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "所以，我——喜欢这份工作！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "今后也会一直继续下去！\n只要有需要培养的人在！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "特别周",
+      "Text": "——咦！？\n理事长和训练员先生已经来了！？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "哎，真的假的！？\n我和小特今天的第一名都没了。",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "菱曙",
+      "Text": "迟到了就更要全力工作～！\n要为蔬菜们松土！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "西野花",
+      "Text": "那个，理事长，大家。\n我有几个想试种的新蔬菜，可以吗……？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "米浴",
+      "Text": "啊，其实米浴也这样想……！\n没关系吗……？",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "当然！尽情追求可能性吧！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "什么会发芽全靠你们！\n一切都是你们的自由！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "葛城王牌",
+      "Text": "——好，大家！今天也开始干活吧～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "大家",
+      "Text": "哦～！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008100.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008100.json
@@ -1,0 +1,23 @@
+{
+  "Title": "日常的照料！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯！在忙碌之中也不忘打理菜地，\n实在是令人佩服！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "无论是种菜还是比赛，都绝非一日之功！\n每天的努力必定会带来丰硕的成果！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008101.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008101.json
@@ -1,0 +1,23 @@
+{
+  "Title": "学园的蔬菜到了！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "蔬菜喷射号，到达！\n我来送蔬菜了！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "骏川手纲",
+      "Text": "呵呵。学园的大家精心照料的蔬菜，\n请好好享用吧♪",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}

--- a/localized_data/stories/story/data/40/0008/storytimeline_400008102.json
+++ b/localized_data/stories/story/data/40/0008/storytimeline_400008102.json
@@ -1,0 +1,29 @@
+{
+  "Title": "美食得道！",
+  "TextBlockList": [
+    {
+      "Name": "",
+      "Text": "",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "嗯～太棒了！\n看来你在美食方面下了不少功夫！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "饮食的充实就是身心的充实！\n这对你们每天的修炼会有很大影响！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    },
+    {
+      "Name": "秋川理事长",
+      "Text": "今后的训练……会和以往有所不同！",
+      "ChoiceDataList": [],
+      "ColorTextInfoList": []
+    }
+  ]
+}


### PR DESCRIPTION
包含该剧本比较常用的主线剧情和提示文本。
因为本仓库的`text_data.json`尚未更新，为避免冲突，把对应的标题先放在这里。
从37175行开始：
```
        "400008000": "开幕！大农耕时代！",
        "400008001": "集结！田地里的伙伴们！",
        "400008002": "教程",
        "400008003": "合宿！农家体验！",
        "400008004": "试吃！收获的成果！",
        "400008005": "大满足！",
        "400008006": "满足！",
        "400008007": "研究！与“食”同行！",
        "400008008": "节制！还有口福！",
        "400008009": "启动！超级蔬菜机械！",
        "400008010": "试作！研究的成果！",
        "400008011": "大饱腹！",
        "400008012": "饱腹！",
        "400008013": "开宴！美食发布会！",
        "400008014": "到来！美食热潮！",
        "400008015": "大成功！",
        "400008016": "成功！",
        "400008017": "告知！超级美食活动！",
        "400008018": "进行！活动准备！",
        "400008019": "准备万全！",
        "400008020": "准备完成！",
        "400008021": "夙愿！我的梦想！",
        "400008022": "各自的“美食”",
        "400008023": "百感交集！学生们的心意！",
        "400008024": "成功！食物的大祭典！",
        "400008025": "超盛况！",
        "400008026": "大盛况！",
        "400008027": "盛况！",
        "400008028": "梦想就在眼前",
        "400008029": "理事长的工作",
        "400008100": "日常的照料！",
        "400008101": "学园的蔬菜到了！",
        "400008102": "美食得道！",
```